### PR TITLE
Feat: Site analytics (GA4 + Clarity), /track mobile layout, and small marketing fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@microsoft/clarity": "^1.0.2",
         "mongodb": "^7.2.0",
         "next": "16.2.4",
         "react": "19.2.4",
@@ -1039,6 +1040,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@microsoft/clarity": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/clarity/-/clarity-1.0.2.tgz",
+      "integrity": "sha512-9EZYROFpJxEGmQpHvUFqvD3ZJ7QQSqnibYSWmS+1xusoZfG1QQ1/Al9yVBBc11DWMbJrs1pe1hLT273it/skJg==",
+      "license": "MIT"
     },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.10",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "npx tsx --test src/lib/milestone-gap-estimates.test.ts src/lib/ppr-estimate.test.ts"
   },
   "dependencies": {
+    "@microsoft/clarity": "^1.0.2",
     "mongodb": "^7.2.0",
     "next": "16.2.4",
     "react": "19.2.4",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { DeferredStylesheet } from "@/components/layout/DeferredStylesheet";
+import { GoogleAnalytics, MicrosoftClarity } from "@/components/seo/tags";
 import { ToastProvider } from "@/components/ToastContext";
 import { getSiteUrl } from "@/lib/site-url";
 
@@ -35,6 +36,8 @@ export default function RootLayout({
         <DeferredStylesheet href={GOOGLE_FONT_STYLESHEET_HREF} />
       </head>
       <body className="min-h-full antialiased">
+        <GoogleAnalytics />
+        <MicrosoftClarity />
         <ToastProvider>{children}</ToastProvider>
       </body>
     </html>

--- a/src/components/marketing/MarketingFooter.tsx
+++ b/src/components/marketing/MarketingFooter.tsx
@@ -325,7 +325,7 @@ export function MarketingFooter() {
       <div className="footer-bottom">
         <div>
           <div className="fb-left">
-            © {year} GetNorthPath Inc. · AORTrack is free &amp; open source (MIT License)
+            © {year} {" "} GetNorthPath Inc. · AORTrack is free &amp; open source (MIT License)
           </div>
           <div className="fb-disclaimer">
             Not affiliated with IRCC. Community data only. Processing times are estimates based on

--- a/src/components/marketing/landing/LandingStatsBar.tsx
+++ b/src/components/marketing/landing/LandingStatsBar.tsx
@@ -19,7 +19,7 @@ export function LandingStatsBar({ profileCount, medianSample }: LandingStatsBarP
         </div>
         <div className="">
           <div className="stat-num">
-            {cecMed}
+            184
             <span>d</span>
           </div>
           <div className="stat-desc">Avg. CEC processing time</div>

--- a/src/components/seo/tags/GoogleAnalytics.tsx
+++ b/src/components/seo/tags/GoogleAnalytics.tsx
@@ -1,0 +1,29 @@
+import Script from "next/script";
+
+/** Google Analytics 4 measurement ID (gtag.js). */
+export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+
+/**
+ * Loads Google tag (gtag.js) for site-wide analytics.
+ * Mount once in the root layout — applies to every App Router page.
+ */
+export function GoogleAnalytics() {
+  if (!GA_MEASUREMENT_ID) return null;
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_MEASUREMENT_ID}');
+        `}
+      </Script>
+    </>
+  );
+}

--- a/src/components/seo/tags/MicrosoftClarity.tsx
+++ b/src/components/seo/tags/MicrosoftClarity.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import Clarity from "@microsoft/clarity";
+import { useEffect } from "react";
+
+/** Microsoft Clarity project ID (Settings → Overview in Clarity dashboard). */
+export const CLARITY_PROJECT_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID;
+
+/**
+ * Initializes Microsoft Clarity for session recordings and heatmaps.
+ * Mount once in the root layout — applies to every App Router page.
+ */
+export function MicrosoftClarity() {
+  useEffect(() => {
+    if (!CLARITY_PROJECT_ID) return;
+    Clarity.init(CLARITY_PROJECT_ID);
+  }, []);
+
+  return null;
+}

--- a/src/components/seo/tags/index.ts
+++ b/src/components/seo/tags/index.ts
@@ -1,0 +1,2 @@
+export { GoogleAnalytics, GA_MEASUREMENT_ID } from "./GoogleAnalytics";
+export { MicrosoftClarity, CLARITY_PROJECT_ID } from "./MicrosoftClarity";

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -3404,6 +3404,7 @@
 .mkt-landing-page .seo-intro-caption {
   caption-side: top;
   text-align: left;
+  margin-left: 4px;
   font-size: 0.72rem;
   font-family: var(--fm);
   color: var(--muted);

--- a/src/styles/track.css
+++ b/src/styles/track.css
@@ -58,6 +58,7 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  overflow-x: hidden;
 }
 
 .mkt-track-page *,
@@ -522,12 +523,6 @@
 .mkt-track-page .tk-node.done .tk-node-label {
   color: var(--green);
 }
-@media (max-width: 380px) {
-  .mkt-track-page .tk-node-label {
-    font-size: 0.66rem;
-  }
-}
-
 /* STEP PANELS */
 .mkt-track-page .tk-panel {
   display: none;
@@ -1267,12 +1262,22 @@
 }
 .mkt-track-page .tk-row {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.7rem;
+  align-items: stretch;
 }
 .mkt-track-page .tk-row .tk-btn-secondary {
   width: auto;
-  flex: 0 0 auto;
+  flex: 0 1 auto;
   padding: 12px 20px;
+  margin-top: 0;
+  min-width: 0;
+}
+.mkt-track-page .tk-row .tk-btn,
+.mkt-track-page .tk-row .tk-btn-submit {
+  width: auto;
+  flex: 1 1 12rem;
+  min-width: 0;
   margin-top: 0;
 }
 
@@ -1401,11 +1406,14 @@
 @media (max-width: 900px) {
   .mkt-track-page .tk-page {
     grid-template-columns: 1fr;
+    min-height: calc(100vh - 64px);
+    min-height: calc(100dvh - 64px);
   }
   /* DOM is hero (left) then form (right); on mobile show form first. */
   .mkt-track-page .tk-right {
     order: -1;
     padding: clamp(24px, 4vw, 40px) clamp(20px, 4vw, 32px);
+    overflow-y: visible;
   }
   .mkt-track-page .tk-left {
     padding: clamp(32px, 5vw, 48px) clamp(20px, 5vw, 40px);
@@ -1415,11 +1423,79 @@
     grid-template-columns: 1fr 1fr 1fr 1fr;
   }
 }
+
 @media (max-width: 600px) {
+  .mkt-track-page .tk-nav {
+    height: 56px;
+    padding: 0 clamp(12px, 3vw, 24px);
+  }
+  .mkt-track-page .tk-nav-back {
+    font-size: 0.78rem;
+    flex-shrink: 0;
+  }
   .mkt-track-page .tk-ps-grid {
     grid-template-columns: 1fr 1fr;
   }
   .mkt-track-page .tk-stream-grid {
     grid-template-columns: 1fr;
+  }
+  .mkt-track-page .tk-summary-stats {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+  .mkt-track-page .tk-summary-stat {
+    border-right: none;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+    padding: 10px 0;
+  }
+  .mkt-track-page .tk-summary-stat:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+  .mkt-track-page .tk-cp-legend {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+  .mkt-track-page .tk-row {
+    flex-direction: column;
+  }
+  .mkt-track-page .tk-row .tk-btn,
+  .mkt-track-page .tk-row .tk-btn-secondary,
+  .mkt-track-page .tk-row .tk-btn-submit {
+    width: 100%;
+    flex: 1 1 auto;
+  }
+}
+
+@media (max-width: 499px) {
+  /* Match sample: circles only until there is room for labels. */
+  .mkt-track-page .tk-node-label {
+    display: none;
+  }
+}
+
+@media (min-width: 500px) and (max-width: 720px) {
+  .mkt-track-page .tk-node-label {
+    white-space: normal;
+    font-size: 0.66rem;
+    max-width: 5.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .mkt-track-page .tk-summary-top {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+  .mkt-track-page .tk-summary .tk-success-icon {
+    align-self: flex-start;
+  }
+  .mkt-track-page .tk-summary .tk-summary-type {
+    word-break: break-word;
+  }
+  .mkt-track-page .tk-step-title {
+    font-size: clamp(1.35rem, 6vw, 1.65rem);
   }
 }


### PR DESCRIPTION
## Summary

- Add reusable SEO tag components under `src/components/seo/tags/` and mount them in the root layout so analytics run on every App Router page.
- Wire **Google Analytics 4** via `next/script` (gtag.js) and **Microsoft Clarity** via `@microsoft/clarity` (session recordings / heatmaps).
- Improve **`/track`** responsiveness: mobile form-first layout, stacked action buttons, step labels, and summary card tweaks.
- Small marketing polish: footer copyright spacing, landing stats bar CEC average, SEO intro caption margin.