### PR TITLE
fix: use median instead of mean for milestone-pace estimates

### DIFF
--- a/src/lib/milestone-gap-estimates.test.ts
+++ b/src/lib/milestone-gap-estimates.test.ts
@@ -49,7 +49,7 @@ function profile(
 }
 
 describe("computeGlobalSeededMilestonePace", () => {
-  it("averages segment gaps and sums to eCOPR total", () => {
+  it("aggregates segment gaps and sums to eCOPR total", () => {
     const pace = computeGlobalSeededMilestonePace([
       profile({
         biometrics: 20,
@@ -102,6 +102,21 @@ describe("computeGlobalSeededMilestonePace", () => {
     }
     assert.equal(pace.total_avg_days_to_ecopr, sum);
     assert.equal(pace.cumulative_avg_days.ecopr, sum);
+  });
+
+  it("uses the median so a single extreme outlier does not inflate the estimate", () => {
+    // Four typical ~30d biometrics gaps plus one stuck 400d applicant.
+    const pace = computeGlobalSeededMilestonePace([
+      profile({ biometrics: 30 }),
+      profile({ biometrics: 28 }),
+      profile({ biometrics: 30 }),
+      profile({ biometrics: 32 }),
+      profile({ biometrics: 400 }),
+    ]);
+
+    // A mean would be (30+28+30+32+400)/5 = 104; the median stays at 30.
+    assert.equal(pace.segment_n.biometrics, 5);
+    assert.equal(pace.segment_avg_days.biometrics, 30);
   });
 });
 

--- a/src/lib/milestone-gap-estimates.ts
+++ b/src/lib/milestone-gap-estimates.ts
@@ -47,14 +47,31 @@ function dateForMilestone(
   return milestoneDate(p.milestones, key);
 }
 
-function meanRounded(values: number[]): number {
+/**
+ * Median segment gap (rounded). Processing-time gaps are right-skewed   a few
+ * stuck applicants (e.g. long background checks) drag a mean upward and inflate
+ * the "typical" estimate for everyone. The median is robust to those outliers,
+ * matching the percentile approach the cohort engine already uses
+ * (`weightedPercentile` in cohort-algorithm-v2.ts).
+ */
+function medianRounded(values: number[]): number {
   if (values.length === 0) return 0;
-  return Math.round(values.reduce((a, b) => a + b, 0) / values.length);
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const med =
+    sorted.length % 2 === 0
+      ? (sorted[mid - 1]! + sorted[mid]!) / 2
+      : sorted[mid]!;
+  return Math.round(med);
 }
 
 /**
- * Average inter-milestone gaps from seeded profiles only (global table).
+ * Median inter-milestone gaps from seeded profiles only (global table).
  * Inspired by aortrack-backend milestone pace spec.
+ *
+ * Note: the result keys (`segment_avg_days`, `cumulative_avg_days`,
+ * `total_avg_days_to_ecopr`) retain their `_avg_` names for back-compat with
+ * already-persisted `milestone_pace` docs; the values are now medians, not means.
  */
 export function computeGlobalSeededMilestonePace(
   profiles: ProfileForMilestonePace[],
@@ -75,7 +92,7 @@ export function computeGlobalSeededMilestonePace(
     }
     segment_n[key] = gaps.length;
     if (gaps.length >= MIN_SEGMENT_N) {
-      segment_avg_days[key] = meanRounded(gaps);
+      segment_avg_days[key] = medianRounded(gaps);
     }
   }
 
@@ -182,7 +199,7 @@ export function milestoneEstimatesFromPace(
     }
     out[key] = {
       estLabel: `~${formatEstDateFromAor(aorDate, row.daysAfterAor)}`,
-      desc: `Typical ~${row.daysAfterAor}d after AOR (avg gaps from ${n} profiles on AOR Track).`,
+      desc: `Typical ~${row.daysAfterAor}d after AOR (median gaps from ${n} profiles on AOR Track).`,
       available: true,
     };
   }


### PR DESCRIPTION
Inter-milestone processing-time gaps are heavily right-skewed, so a single stuck applicant (e.g. a long background check) dragged the mean-based "typical" estimate upward for everyone. Switch the seeded milestone-pace aggregation to a median, which is robust to those outliers and consistent with the percentile approach the cohort engine already uses (weightedPercentile).

Persisted field names (segment_avg_days, cumulative_avg_days, total_avg_days_to_ecopr) are kept for back-compat with already-stored milestone_pace docs; only the computation changes. Adds a regression test: for gaps [30,28,30,32,400] a mean reports 104d, the median 30d.