### PR TITLE
Fix broken privacy policy link in TrackStep3Review

### DIFF
--- a/src/components/track/TrackStep3Review.tsx
+++ b/src/components/track/TrackStep3Review.tsx
@@ -259,7 +259,7 @@ export function TrackStep3Review(props: Props) {
         <span className="tk-consent-text">
           I agree to the{" "}
           <a
-            href="/privacy"
+            href="https://www.getnorthpath.com/privacy"
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## Summary

The privacy policy link in TrackStep3Review pointed to `/privacy`,
which returns a 404 on production.

This change updates the link to use the canonical privacy policy URL already used in the footer.

## Testing

- Verified `/privacy` returns 404 on production
- Verified the footer links to the working privacy policy page
- Verified the updated link opens the correct privacy policy page