### PR TITLE
fix: render dynamic cohort note in V2 timeline

### DIFF
--- a/src/components/dashboard/v2/DashboardTimeline.tsx
+++ b/src/components/dashboard/v2/DashboardTimeline.tsx
@@ -12,7 +12,6 @@ import {
   IconCheck,
   IconCheckCircle,
   IconEdit,
-  IconInfo,
   IconPlus,
   IconSync,
 } from "./dashboard-icons";
@@ -192,8 +191,7 @@ export function DashboardTimeline({
         <div>
           <div className="sec-title">My Milestone Timeline</div>
           <div className="sec-sub">
-            Hover any row to edit your date   updates are community-verified before
-            contributing to community stats
+            {note}
           </div>
         </div>
       </div>

--- a/src/lib/cohort-sync-job.ts
+++ b/src/lib/cohort-sync-job.ts
@@ -19,8 +19,7 @@ import {
   computeGlobalSeededMilestonePace,
   milestonePaceFilter,
 } from "@/lib/milestone-gap-estimates";
-import { emptyCohortStats } from "@/lib/seed";
-import type { CohortStats, MilestoneKey } from "@/lib/types";
+import type { MilestoneKey } from "@/lib/types";
 
 function profileFieldsFromDoc(doc: Record<string, unknown>): ProfileForStats & {
   stream: string;
@@ -82,7 +81,6 @@ function aggregateOneCohort(
   cutoffIso: string,
   p1Global: ReturnType<typeof computeP1Percentiles>,
 ): Record<string, unknown> {
-  const empty = emptyCohortStats(cohortKey);
   const distResult = computeCohortDistribution(
     cohortProfiles.map(toProfileForStats),
     cutoffIso,


### PR DESCRIPTION
## Summary

This PR fixes a V2 dashboard timeline rendering issue where contextual cohort information was not being displayed to the user.


---

## Problem

`DashboardTimelineTabV2` generates and passes a dynamic `note` prop containing useful cohort context. However, `DashboardTimeline` rendered a static subtitle instead of the provided note, preventing this information from being shown.

---

## Changes Made

### Dashboard Timeline

* Updated `DashboardTimeline` to render the dynamic `note` prop.
* Replaced the hardcoded subtitle text with contextual cohort information.
* Removed the unused `IconInfo` import.

### Code Cleanup

* Removed unused variables and imports from `cohort-sync-job.ts`.
* Performed small related cleanup discovered during implementation.

---

## Impact

This change improves the visibility of existing cohort information without modifying the underlying dashboard logic or data flow.

Users can now see the contextual information already generated by the V2 dashboard, making the timeline more informative while preserving the existing UI and behaviour.

---

## Verification

* [x] Verified that the dynamic cohort note is displayed correctly.
* [x] Confirmed existing timeline functionality remains unchanged.
* [x] No changes to business logic or cohort calculations.
* [x] Small cleanup completed without affecting functionality.

Fixes #72 
