### PR TITLE
docs: Add CONTRIBUTING workflow, issue templates, and self-service issue links

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default reviewers for all paths. Add more @usernames as the maintainer team grows.
+* @Apurva-Prajapati-work
+* @Piyush-Use-Personal
+* @pushoo-sharma

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: Bug report
+description: Something is broken or behaving incorrectly
+title: "fix: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. A linked issue is **required** before any PR can merge.
+        See [CONTRIBUTING.md](https://github.com/Get-North-Path/AOR-tracker/blob/main/CONTRIBUTING.md).
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What went wrong? Which page or feature?
+      placeholder: On /roadmap, the Done column shows...
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps so we can see the same behavior.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or recordings
+      description: Optional but very helpful. Drag and drop images here.
+      placeholder: Paste screenshots or links to recordings.
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        By submitting this issue, you understand that a **pull request must link this issue** before it can be merged.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Open an issue (templates)
+    url: https://github.com/Get-North-Path/AOR-tracker/issues/new/choose
+    about: Contributors create issues themselves — pick bug, feature, data, or docs.
+  - name: Contributing guide
+    url: https://github.com/Get-North-Path/AOR-tracker/blob/main/CONTRIBUTING.md
+    about: Branch naming, commits, and PR rules after your issue is open.
+  - name: Security report (email only)
+    url: https://github.com/Get-North-Path/AOR-tracker/blob/main/SECURITY.md
+    about: Do not open public issues for vulnerabilities — email info@getnorthpath.com.
+  - name: Discord community
+    url: https://discord.gg/aortrack
+    about: Informal chat — GitHub Issues are required before code changes merge.

--- a/.github/ISSUE_TEMPLATE/data_correction.yml
+++ b/.github/ISSUE_TEMPLATE/data_correction.yml
@@ -1,0 +1,47 @@
+name: Data / cohort correction
+description: Report incorrect cohort stats, medians, or stream data
+title: "data: "
+labels:
+  - data
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for wrong processing times, cohort medians, or stream-specific data.
+        A linked issue is **required** before any PR can merge.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Summarize the data problem.
+      placeholder: CEC Jan 2024 cohort median PPR day looks too low compared to ...
+    validations:
+      required: true
+  - type: textarea
+    id: wrong_data
+    attributes:
+      label: What data is wrong?
+      description: Stream, cohort month, milestone, URL, or API response if relevant.
+      placeholder: |
+        Stream: CEC
+        Cohort: 2024-01
+        Field: median days to PPR
+        Current value shown: 120
+        Expected (and source): ...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How will we know the fix is correct?
+      placeholder: |
+        - [ ] Median matches recalculated community sample
+        - [ ] Dashboard and public stream page agree
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        By submitting this issue, you understand that a **pull request must link this issue** before it can be merged.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,33 @@
+name: Documentation
+description: Improve README, guides, copy, or contributor docs
+title: "docs: "
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Documentation-only changes still need an issue before a PR merges.
+        See [CONTRIBUTING.md](https://github.com/Get-North-Path/AOR-tracker/blob/main/CONTRIBUTING.md).
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What should be documented or clarified?
+      placeholder: README setup steps are missing GITHUB_TOKEN for roadmap...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] README section added under Contributing
+        - [ ] Wording reviewed for applicant-friendly tone
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        By submitting this issue, you understand that a **pull request must link this issue** before it can be merged.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Suggest a new feature or improvement
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. A linked issue is **required** before any PR can merge.
+        See [CONTRIBUTING.md](https://github.com/Get-North-Path/AOR-tracker/blob/main/CONTRIBUTING.md).
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What problem does this solve? Who benefits?
+      placeholder: As a PR applicant, I want to ...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Checklist of what "done" looks like.
+      placeholder: |
+        - [ ] User can ...
+        - [ ] Page shows ...
+        - [ ] Works on mobile
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or mockups
+      description: Optional sketches, Figma links, or examples from other sites.
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        By submitting this issue, you understand that a **pull request must link this issue** before it can be merged.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What does this PR do? Link the issue below. -->
+
+Fixes #
+
+## Checklist
+
+- [ ] Linked issue: `Fixes #___` (required — see [CONTRIBUTING.md](../CONTRIBUTING.md))
+- [ ] Branch name follows `username/short-slug`
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] `npm run lint` passes
+- [ ] `npm run build` passes
+- [ ] Screenshots attached (if UI change)
+
+## Notes for reviewers
+
+<!-- Anything non-obvious? Areas you want extra eyes on? -->
+
+---
+
+Only **org members / maintainers** merge PRs. Contributors do not push version tags or publish releases.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,147 @@
+# Contributing to AORTrack
+
+Thank you for helping improve AORTrack. This project is **built by applicants, for applicants** — and we welcome contributions across the full stack: marketing pages, dashboard UI, API routes, MongoDB, cohort data, and documentation.
+
+Please read this guide before opening a pull request.
+
+---
+
+## Before you code
+
+1. **You create the GitHub Issue yourself** — we do not open issues on your behalf and we do not accept drive-by PRs without a linked issue.
+2. **Open a new issue** on the org repo (free GitHub account required):
+
+   **[github.com/Get-North-Path/AOR-tracker/issues/new/choose](https://github.com/Get-North-Path/AOR-tracker/issues/new/choose)**
+
+3. **Pick the right template:**
+   - Bug report
+   - Feature request
+   - Data / cohort correction
+   - Documentation
+4. **New to the repo?** Look for issues labelled [`good first issue`](https://github.com/Get-North-Path/AOR-tracker/issues?q=label%3A%22good+first+issue%22).
+5. **Security vulnerabilities** — never open a public issue. See [SECURITY.md](SECURITY.md).
+6. **Discord** ([discord.gg/aortrack](https://discord.gg/CA8FcsTH44)) is optional for chat; **GitHub Issues are the official entry point** for work we will merge.
+
+---
+
+## Writing a good issue
+
+| Type | Include |
+|------|---------|
+| **Bug** | Clear description, steps to reproduce, expected vs actual behavior. Screenshots help. |
+| **Feature** | Problem you're solving, acceptance criteria (checklist of done-when items). Mockups welcome. |
+| **Data** | What data is wrong, which stream/cohort/date range, and how you verified it. |
+| **Docs** | What to change and who it helps. |
+
+You own the issue you opened — update it with comments or screenshots as you learn more. For large features, wait for maintainer feedback before opening a PR; small bugfixes can move forward once the issue is clear.
+
+---
+
+## Development setup
+
+See [README.md](README.md) for:
+
+- `npm run dev` / `npm run dev:next`
+- Environment variables (`MONGODB_URI`, `GITHUB_TOKEN`, etc.)
+- Local URL: [http://localhost:3000](http://localhost:3000)
+
+---
+
+## Branch naming
+
+Use your GitHub username and a short slug:
+
+```text
+your-username/short-description
+```
+
+Examples:
+
+- `apurv/roadmap-mobile-scroll`
+- `apurv/fix-changelog-parser`
+
+---
+
+## Commit messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/):
+
+| Prefix | When to use |
+|--------|-------------|
+| `feat:` | New feature |
+| `fix:` | Bug fix |
+| `data:` | Dataset or calculation change |
+| `docs:` | Documentation only |
+| `style:` | Formatting, no logic change |
+| `refactor:` | Code restructure |
+| `test:` | Adding or fixing tests |
+| `chore:` | Build, CI, tooling |
+
+Optional scope in parentheses:
+
+```text
+feat(roadmap): improve mobile kanban scroll
+fix(changelog): parse issue links in release notes
+docs: add CONTRIBUTING guide
+```
+
+---
+
+## Pull request process
+
+### 1. Fork and branch
+
+```bash
+git clone https://github.com/YOUR_USERNAME/AOR-tracker.git
+cd AOR-tracker
+git checkout -b your-username/short-description
+```
+
+### 2. Make changes
+
+Run these before opening a PR:
+
+```bash
+npm run lint
+npm run build
+```
+
+### 3. Open a PR to the org repo
+
+Target **`Get-North-Path/AOR-tracker`** branch **`main`** (not your fork's default if you contribute upstream).
+
+In the PR description, link the issue:
+
+```text
+Fixes #123
+```
+
+Cross-repo example with GitHub CLI:
+
+```bash
+git push -u origin your-username/short-description
+gh pr create --repo Get-North-Path/AOR-tracker --base main --head YOUR_USERNAME:your-username/short-description
+```
+
+### 4. Review and merge
+
+- At least **one maintainer review** is required.
+- Only **org members / maintainers** merge PRs.
+- **Contributors must not** push version tags or publish GitHub Releases.
+
+### 5. After your PR merges
+
+Maintainers cut releases (`v*` tags). Published releases appear on [track.getnorthpath.com/changelog](https://track.getnorthpath.com/changelog) after the next cache refresh. No action needed from you.
+
+---
+
+## Questions?
+
+- Comment on your GitHub issue or PR
+- Ask in [Discord](https://discord.gg/aortrack)
+
+---
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the same [MIT License](LICENSE) as the project.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,12 @@ Open [http://localhost:3000](http://localhost:3000).
 
 ## 🤝 Contributing
 
-We welcome **issues, PRs, and design feedback** on GitHub. For larger changes, open an issue first so we can align on scope. Join **[Discord](https://discord.gg/aortrack)** for informal discussion and release chatter.
+We welcome **issues, PRs, and design feedback** on GitHub.
+
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** — how to open issues, branch naming, commit format, and PR rules
+- **[Open an issue yourself](https://github.com/Get-North-Path/AOR-tracker/issues/new/choose)** before opening a PR (required)
+- **[SECURITY.md](SECURITY.md)** — report vulnerabilities to info@getnorthpath.com (not public issues)
+- **[Discord](https://discord.gg/aortrack)** — informal discussion and release chatter
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Do not** open a public GitHub Issue or Pull Request for security vulnerabilities.
+
+Email **info@getnorthpath.com** with:
+
+- A description of the issue
+- Steps to reproduce (if applicable)
+- Potential impact (data exposure, auth bypass, etc.)
+- Any proof-of-concept you are comfortable sharing
+
+We will acknowledge your report within **72 hours** and work with you on a fix and disclosure timeline.
+
+## What we ask of reporters
+
+- Give us reasonable time to investigate and patch before public disclosure.
+- Do not access, modify, or delete data that is not yours.
+
+## Credit
+
+With your permission, we may thank security researchers in release notes after a fix ships.
+
+## Supported versions
+
+Security fixes are applied to the latest release on the `main` branch. We recommend running the current production deployment.

--- a/src/components/changelog/ChangelogSidebar.tsx
+++ b/src/components/changelog/ChangelogSidebar.tsx
@@ -16,7 +16,7 @@ const DEFAULT_EXTERNAL_LINKS: NonNullable<Props["externalLinks"]> = [
     external: true,
   },
   {
-    href: "https://github.com/Get-North-Path/AOR-tracker/issues/new",
+    href: "https://github.com/Get-North-Path/AOR-tracker/issues/new/choose",
     label: "Give Feedback",
   },
 ];

--- a/src/components/dashboard/v2/live-vm.ts
+++ b/src/components/dashboard/v2/live-vm.ts
@@ -488,7 +488,7 @@ export function sidebarSectionsVM({
       key: "feedback",
       label: "Give Feedback",
       icon: "plus",
-      href: "https://github.com/Get-North-Path/AOR-tracker/issues/new",
+      href: "https://github.com/Get-North-Path/AOR-tracker/issues/new/choose",
     },
   ];
 

--- a/src/components/marketing/community/data.ts
+++ b/src/components/marketing/community/data.ts
@@ -25,7 +25,7 @@ import type { CommunityMsCounts } from "@/app/actions/community";
 const SUBMIT_HREF = "/track";
 const DASHBOARD_HREF = "/dashboard";
 const FEEDBACK_HREF =
-  "https://github.com/Get-North-Path/AOR-tracker/issues/new";
+  "https://github.com/Get-North-Path/AOR-tracker/issues/new/choose";
 const DISCORD_HREF = "https://discord.gg/aortrack";
 
 // ─── Types ──────────────────────────────────────────────────────────────────

--- a/src/components/marketing/roadmap/RoadmapCtaBand.tsx
+++ b/src/components/marketing/roadmap/RoadmapCtaBand.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { IconArrowRight, IconPlus } from "./roadmap-icons";
 
 type Props = {
@@ -7,8 +6,8 @@ type Props = {
 };
 
 /**
- * Dark navy CTA band that sits above the kanban   "Don't see what you need?"
- * with two CTAs (Request Feature, View GitHub Issues).
+ * Dark navy CTA band above the kanban — links contributors to open their own
+ * GitHub issues (see CONTRIBUTING.md).
  */
 export function RoadmapCtaBand({ feedbackHref, issuesHref }: Props) {
   return (
@@ -16,15 +15,20 @@ export function RoadmapCtaBand({ feedbackHref, issuesHref }: Props) {
       <div className="rm-ctab-text">
         <h3>Don&apos;t see what you need?</h3>
         <p>
-          Submit a feature request, bug, or data correction   no GitHub account
-          required. We handle the issue creation automatically.
+          Open a GitHub Issue yourself — pick a template for bugs, features,
+          data fixes, or docs. A free GitHub account is required.
         </p>
       </div>
       <div className="rm-ctab-btns">
-        <Link href={feedbackHref} className="rm-btn rm-btn-r">
+        <a
+          href={feedbackHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rm-btn rm-btn-r"
+        >
           <IconPlus aria-hidden />
-          Request Feature
-        </Link>
+          Open GitHub Issue
+        </a>
         <a
           href={issuesHref}
           target="_blank"

--- a/src/components/marketing/roadmap/RoadmapNav.tsx
+++ b/src/components/marketing/roadmap/RoadmapNav.tsx
@@ -8,7 +8,7 @@ type Props = {
   changelogHref: string;
   /** Public repo URL. */
   repoHref: string;
-  /** Feature request entry point. */
+  /** GitHub issue template chooser (contributors open issues themselves). */
   feedbackHref: string;
 };
 
@@ -44,10 +44,15 @@ export function RoadmapNav({
           <IconGitHub aria-hidden />
           GitHub
         </a>
-        <Link href={feedbackHref} className="rm-nbtn red">
+        <a
+          href={feedbackHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rm-nbtn red"
+        >
           <IconPlus aria-hidden />
           Request Feature
-        </Link>
+        </a>
       </div>
     </nav>
   );

--- a/src/components/marketing/roadmap/data.ts
+++ b/src/components/marketing/roadmap/data.ts
@@ -481,7 +481,8 @@ const seedRoadmap: RoadmapData = {
   links: {
     repo: REPO,
     issues: ISSUES_URL,
-    feedback: "https://github.com/Get-North-Path/AOR-tracker/issues/new",
+    feedback:
+      "https://github.com/Get-North-Path/AOR-tracker/issues/new/choose",
     changelog: "/changelog",
     issueBase: ISSUES_URL,
   },

--- a/src/components/track/TrackSuccess.tsx
+++ b/src/components/track/TrackSuccess.tsx
@@ -57,7 +57,7 @@ export function TrackSuccess() {
         </Link>
 
         <Link
-          href="https://github.com/Get-North-Path/AOR-tracker/issues/new"
+          href="https://github.com/Get-North-Path/AOR-tracker/issues/new/choose"
           className="tk-na"
         >
           <span className="tk-na-ic tk-na-blue">
@@ -66,7 +66,7 @@ export function TrackSuccess() {
           <div className="tk-na-text">
             <div className="tk-na-title">Give feedback on AORTrack</div>
             <div className="tk-na-desc">
-              Help us improve   no GitHub account needed
+              Open a GitHub Issue to suggest improvements
             </div>
           </div>
           <span className="tk-na-arrow" aria-hidden="true">


### PR DESCRIPTION
## Summary
- Add CONTRIBUTING.md, SECURITY.md, GitHub issue templates (bug, feature, data, docs), PR template, and CODEOWNERS for maintainer review routing.
- Document issue-first workflow, Conventional Commits, `username/slug` branches, and fork → org PR process with lint/build gates.
- Point roadmap, community, dashboard, track, and changelog feedback links to GitHub issue template chooser so contributors open issues themselves.

## Test plan
- [ ] Open https://github.com/Get-North-Path/AOR-tracker/issues/new/choose after merge and confirm all four templates appear
- [ ] Open a test PR and confirm pull_request_template.md checklist loads
- [ ] Verify README and CONTRIBUTING links resolve
- [ ] Click “Open GitHub Issue” on /roadmap and confirm it opens the template chooser
- [ ] Confirm SECURITY.md shows info@getnorthpath.com reporting path