### PR TITLE
fix: Use anchor tags for external GitHub links on roadmap page

### DIFF
--- a/src/components/marketing/roadmap/RoadmapCtaBand.tsx
+++ b/src/components/marketing/roadmap/RoadmapCtaBand.tsx
@@ -31,7 +31,7 @@ export function RoadmapCtaBand({ feedbackHref, issuesHref }: Props) {
           <span className="rm-btn-short" aria-hidden>
             Request
           </span>
-        </Link>
+        </a>
         <a
           href={issuesHref}
           target="_blank"

--- a/src/components/marketing/roadmap/RoadmapNav.tsx
+++ b/src/components/marketing/roadmap/RoadmapNav.tsx
@@ -59,7 +59,7 @@ export function RoadmapNav({
           <span className="rm-nbtn-short" aria-hidden>
             Request
           </span>
-        </Link>
+        </a>
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary

- Fixes incorrect navigation on the roadmap page where "Request Feature" buttons used Next.js `Link` for external GitHub issue URLs, causing client-side routing instead of opening GitHub in a new tab
- Replaces closing `</Link>` with `</a>` in `RoadmapCtaBand` and `RoadmapNav` so external feedback links render as standard anchor tags (matching the opening `<a>` elements)

## Test plan

- [ ] Open `/roadmap` and click **Request Feature** in the top nav — should open the GitHub issue template chooser in a new tab
- [ ] Click **Request Feature** in the CTA band below the hero — same behavior
- [ ] Confirm **Changelog** still navigates in-app via Next.js `Link`
- [ ] Confirm **GitHub** and **View GitHub Issues** links still open externally in a new tab